### PR TITLE
Enable par dynamic redirect paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1360,6 +1360,7 @@ _**default value**_:
 {
   enabled: false,
   requirePushedAuthorizationRequests: false
+  allowDynamicRedirectUris: false
 }
 ```
 
@@ -1368,7 +1369,11 @@ _**default value**_:
 
 #### requirePushedAuthorizationRequests
 
-Makes the use of PAR required for all authorization requests as an OP policy.  
+Makes the use of PAR required for all authorization requests as an OP policy.
+
+#### allowDynamicRedirectUris
+
+Allow dynamic paths in redirect URIs for PAR. Domain name must still match.  
 
 
 _**default value**_:

--- a/lib/actions/authorization/check_redirect_uri.js
+++ b/lib/actions/authorization/check_redirect_uri.js
@@ -1,12 +1,31 @@
 const { InvalidRedirectUri } = require('../../helpers/errors');
+const instance = require('../../helpers/weak_cache');
+
+const PAR = 'pushed_authorization_request';
+const AUTH = 'authorization';
 
 /*
  * Checks that provided redirect_uri is allowed in the client configuration
  *
+ * If pushed authorization requests enabled with dynamic redirect URIs,
+ * checks redirect URI has same domain as registered URI
+ *
  * @throws: invalid_redirect_uri
  */
 module.exports = function checkRedirectUri(ctx, next) {
-  if (!ctx.oidc.client.redirectUriAllowed(ctx.oidc.params.redirect_uri)) {
+  const {
+    pushedAuthorizationRequests: {
+      enabled, allowDynamicRedirectUris,
+    },
+  } = instance(ctx.oidc.provider).configuration('features');
+
+  const isPAR = ctx.oidc.route === PAR
+    || (ctx.oidc.route === AUTH && ctx.oidc.entities.PushedAuthorizationRequest);
+
+  const isDomainRedirectAllowed = enabled && allowDynamicRedirectUris
+    && isPAR;
+
+  if (!ctx.oidc.client.redirectUriAllowed(ctx.oidc.params.redirect_uri, isDomainRedirectAllowed)) {
     throw new InvalidRedirectUri();
   } else {
     ctx.oidc.redirectUriCheckPerformed = true;

--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -35,6 +35,7 @@ module.exports = function discovery(ctx, next) {
   if (pushedAuthorizationRequests.enabled) {
     ctx.body.pushed_authorization_request_endpoint = ctx.oidc.urlFor('pushed_authorization_request');
     ctx.body.require_pushed_authorization_requests = pushedAuthorizationRequests.requirePushedAuthorizationRequests ? true : undefined;
+    ctx.body.allow_dynamic_redirect_uris = pushedAuthorizationRequests.allowDynamicRedirectUris ? true : undefined;
   }
 
   if (requestObjects.request || requestObjects.requestUri || pushedAuthorizationRequests.enabled) {

--- a/lib/consts/client_attributes.js
+++ b/lib/consts/client_attributes.js
@@ -38,6 +38,7 @@ const DEFAULT = {
   post_logout_redirect_uris: [],
   require_auth_time: false,
   require_pushed_authorization_requests: false,
+  allow_dynamic_redirect_uris: false,
   require_signed_request_object: false,
   response_types: ['code'],
   subject_type: 'public',
@@ -57,6 +58,7 @@ const BOOL = [
   'backchannel_user_code_parameter',
   'require_auth_time',
   'require_pushed_authorization_requests',
+  'allow_dynamic_redirect_uris',
   'require_signed_request_object',
   'tls_client_certificate_bound_access_tokens',
 ];

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -129,6 +129,7 @@ module.exports = function getSchema(provider) {
 
   if (features.pushedAuthorizationRequests.enabled) {
     RECOGNIZED_METADATA.push('require_pushed_authorization_requests');
+    RECOGNIZED_METADATA.push('allow_dynamic_redirect_uris');
   }
 
   if (features.encryption.enabled) {
@@ -643,8 +644,13 @@ module.exports = function getSchema(provider) {
 
     parPolicy() {
       const par = configuration.features.pushedAuthorizationRequests;
-      if (par.enabled && par.requirePushedAuthorizationRequests) {
-        this.require_pushed_authorization_requests = true;
+      if (par.enabled) {
+        if (par.requirePushedAuthorizationRequests) {
+          this.require_pushed_authorization_requests = true;
+        }
+        if (par.allowDynamicRedirectUris) {
+          this.allow_dynamic_redirect_uris = true;
+        }
       }
     }
 

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -126,6 +126,13 @@ function deriveEncryptionKey(secret, length) {
   return base64url.encodeBuffer(derived);
 }
 
+function matchDomain(parsedUri, registeredUris) {
+  return !!registeredUris.find((registeredUri) => {
+    const removedTrailingSlash = registeredUri.replace(/\/$/, ''); // strips trailing slash from registered URI
+    return parsedUri.origin === removedTrailingSlash;
+  });
+}
+
 module.exports = function getClient(provider) {
   const staticCache = new Map();
   const dynamicCache = new QuickLRU({ maxSize: 100 });
@@ -484,7 +491,7 @@ module.exports = function getClient(provider) {
       return this.grantTypes.includes(type);
     }
 
-    redirectUriAllowed(value) {
+    redirectUriAllowed(value, allowDomainMatch) {
       let parsed;
       try {
         parsed = new URL(value);
@@ -492,7 +499,10 @@ module.exports = function getClient(provider) {
         return false;
       }
 
-      const match = this.redirectUris.includes(value);
+      const match = allowDomainMatch
+        ? matchDomain(parsed, this.redirectUris)
+        : this.redirectUris.includes(value);
+
       if (
         match
         || this.applicationType !== 'native'

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -993,6 +993,28 @@ describe('Client metadata validation', () => {
         clientDefaults: { require_pushed_authorization_requests: true },
       });
     });
+
+    context('allow_dynamic_redirect_uris', function () {
+      const configuration = (value = false) => ({
+        features: {
+          pushedAuthorizationRequests: {
+            enabled: true,
+            allowDynamicRedirectUris: value,
+          },
+        },
+      });
+      mustBeBoolean(this.title, undefined, configuration());
+      mustBeBoolean(this.title, undefined, configuration(true));
+      defaultsTo(this.title, false, undefined, configuration());
+      defaultsTo(this.title, true, undefined, configuration(true));
+      defaultsTo(this.title, true, {
+        allow_dynamic_redirect_uris: false,
+      }, configuration(true));
+      defaultsTo(this.title, true, undefined, {
+        ...configuration(),
+        clientDefaults: { allow_dynamic_redirect_uris: true },
+      });
+    });
   });
 
   describe('features.ciba', () => {

--- a/test/pushed_authorization_requests/pushed_authorization_requests.config.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.config.js
@@ -7,6 +7,7 @@ config.enabledJWA.requestObjectSigningAlgValues = config.enabledJWA.requestObjec
 
 merge(config.features, {
   pushedAuthorizationRequests: {
+    allowDynamicRedirectUris: false,
     requirePushedAuthorizationRequests: false,
     enabled: true,
   },
@@ -32,5 +33,14 @@ module.exports = {
     client_secret: 'secret',
     request_object_signing_alg: 'HS256',
     redirect_uris: ['https://rp.example.com/cb'],
-  }],
+  }, {
+    client_id: 'client-allow-par-dynamic-redirect',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com'],
+  }, {
+    client_id: 'client-redirect-trailing-slash',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com/'],
+  },
+  ],
 };


### PR DESCRIPTION
### Description
Adds config to the `oidc-provider` package that allows dynamic paths in redirect URIs for Pushed Authorization Requests only. This allows only a domain to be registered as the redirect URI on the API client. Requests will work as long as the redirect URI on a request matches the registered domain.

The intention is to raise this as PR to the main `oidc-provider` repo (keeping this PR on the fork for now).

- Makes us of the existing `checkRedirectUri` function. Requires that the config option `allowDynamicRedirectUris` is enabled.
- If the route being called is the PAR endpoint (`/request`) or there is a registered PAR already in the `/auth` endpoint, it will allow only the domain to match if the config option is enabled.
- Allows multiple domains to be registered on clients (as multiple redirect URIs are already possible)
- Allows registered domains to have a trailing slash