### PR TITLE
Redirect uri domain matching

### DIFF
--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -127,11 +127,10 @@ function deriveEncryptionKey(secret, length) {
   return base64url.encodeBuffer(derived);
 }
 
-function matchDomain(parsedUri, registeredUris) {
-  return !!registeredUris.find((registeredUri) => {
-    const removedTrailingSlash = registeredUri.replace(/\/$/, ''); // strips trailing slash from registered URI
-    return parsedUri.origin === removedTrailingSlash;
-  });
+function matchDomain(parsedUri, parsedRegisteredUris) {
+  return !!parsedRegisteredUris.find(
+    (parsedRegisteredUri) => parsedUri.origin === parsedRegisteredUri.origin,
+  );
 }
 
 module.exports = function getClient(provider) {
@@ -506,8 +505,10 @@ module.exports = function getClient(provider) {
         return false;
       }
 
+      const parsedRegisteredUris = this.redirectUris.map((uri) => new URL(uri));
+
       const match = allowDomainMatch
-        ? matchDomain(parsed, this.redirectUris)
+        ? matchDomain(parsed, parsedRegisteredUris)
         : this.redirectUris.includes(value);
 
       if (

--- a/test/pushed_authorization_requests/pushed_authorization_requests.config.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.config.js
@@ -41,6 +41,10 @@ module.exports = {
     client_id: 'client-redirect-trailing-slash',
     client_secret: 'secret',
     redirect_uris: ['https://rp.example.com/'],
+  }, {
+    client_id: 'client-redirect-with-path',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com/test'],
   },
   ],
 };

--- a/test/pushed_authorization_requests/pushed_authorization_requests.test.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.test.js
@@ -531,7 +531,7 @@ describe('Pushed Request Object', () => {
     });
   });
 
-  ['client-allow-par-dynamic-redirect', 'client-redirect-trailing-slash'].forEach((clientId) => {
+  ['client-allow-par-dynamic-redirect', 'client-redirect-trailing-slash', 'client-redirect-with-path'].forEach((clientId) => {
     const trailingSlash = clientId === 'client-redirect-trailing-slash' ? 'with' : 'without';
     describe(`when allow_dynamic_redirect_uris=true ${trailingSlash} trailing slash`, () => {
       before(function () {


### PR DESCRIPTION
Before the redirect URI domains were being compared by parsing the provided redirect URI, grabbing the URL.origin and comparing that to the whole redirect_uri string registered on client. Now it is also parsing the registered redirect_uri to also grab the URL.origin.

This change makes the matching of URIs a little bit more resilient to cases where a path has been given on the registered URL. So now oidc-provider will compare the origin e.g. https://localhost:3000/ regardless of if there is a path or not. So if a redirect https://localhost/some/path is registered on the client, that domain will be considered as authorised so a different path could be provided e.g. https://localhost/other/path.

This also paves the way in the future for potential